### PR TITLE
Add classification and objectClassification to normalizeValueKey

### DIFF
--- a/src/bq-utils.ts
+++ b/src/bq-utils.ts
@@ -271,7 +271,9 @@ type NormalizedKey =
   | "value"
   | "objectCondition"
   | "objectTherapy"
-  | "conditionQualifier";
+  | "conditionQualifier"
+  | "classification"
+  | "objectClassification";
 
 const PREFIX_MAP: Record<string, NormalizedKey> = {
   start: "start",
@@ -281,6 +283,8 @@ const PREFIX_MAP: Record<string, NormalizedKey> = {
   objectCondition: "objectCondition",
   objectTherapy: "objectTherapy",
   conditionQualifier: "conditionQualifier",
+  classification: "classification",
+  objectClassification: "objectClassification",
 };
 
 function normalizeValueKey(

--- a/test/bq-utils.test.js
+++ b/test/bq-utils.test.js
@@ -256,6 +256,8 @@ test('normalizeValueKey should normalize keys correctly', () => {
   expect(normalizeValueKey('value_test', 'test')).toEqual({ key: 'value', value: 'test' });
   expect(normalizeValueKey('objectCondition_complex', 'condition')).toEqual({ key: 'objectCondition', value: 'condition' });
   expect(normalizeValueKey('copies_int', 'context')).toEqual({ key: 'copies', value: 'context' });
+  expect(normalizeValueKey('classification_simple', 'Pathogenic')).toEqual({ key: 'classification', value: 'Pathogenic' });
+  expect(normalizeValueKey('objectClassification_complex', 'Benign')).toEqual({ key: 'objectClassification', value: 'Benign' });
 
   // Test invalid keys
   expect(normalizeValueKey('invalid_key', 'test')).toBeUndefined();


### PR DESCRIPTION
## Summary
- Add `classification` and `objectClassification` to the `NormalizedKey` type and `PREFIX_MAP` in `normalizeValueKey()`
- Add test assertions for both new key prefixes

## Test plan
- [x] Existing tests pass (61/61)
- [x] New assertions verify `classification_simple` and `objectClassification_complex` normalize correctly