### PR TITLE
Fix mermaid diagram rendering in MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
+          format: !!python/name:pymdownx.superfences.fence_mermaid_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.details


### PR DESCRIPTION
## Summary
- Switch `pymdownx.superfences` format from `fence_code_format` to `fence_mermaid_format` in `mkdocs.yml`
- Fixes mermaid diagrams not rendering on the landing page, Data Pipeline page, and CI/CD page

## Details
`fence_code_format` wraps mermaid content in `<code class="language-mermaid">` which the Material theme's JS doesn't recognize. `fence_mermaid_format` (available since pymdownx-extensions 10.3) wraps it in `<pre class="mermaid">` which the theme picks up and renders.

## Test plan
- [ ] Run `mkdocs serve` and verify mermaid diagrams render on Home, Data Pipeline, and CI/CD pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)