### PR TITLE
Fix docs CI: pin pymdown-extensions>=10.3

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install MkDocs and dependencies
-        run: pip install mkdocs-material
+        run: pip install mkdocs-material "pymdown-extensions>=10.3"
 
       - name: Build and deploy
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- Pin `pymdown-extensions>=10.3` in the docs workflow to ensure `fence_mermaid_format` is available
- Fixes the deploy failure introduced when mkdocs.yml switched from `fence_code_format` to `fence_mermaid_format`

## Test plan
- [ ] Docs workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)