### PR TITLE
feat: add objectConditionClassification to NormalizedKey

### DIFF
--- a/src/bq-utils.ts
+++ b/src/bq-utils.ts
@@ -273,7 +273,8 @@ type NormalizedKey =
   | "objectTherapy"
   | "conditionQualifier"
   | "classification"
-  | "objectClassification";
+  | "objectClassification"
+  | "objectConditionClassification";
 
 const PREFIX_MAP: Record<string, NormalizedKey> = {
   start: "start",
@@ -285,6 +286,7 @@ const PREFIX_MAP: Record<string, NormalizedKey> = {
   conditionQualifier: "conditionQualifier",
   classification: "classification",
   objectClassification: "objectClassification",
+  objectConditionClassification: "objectConditionClassification",
 };
 
 function normalizeValueKey(


### PR DESCRIPTION
## Summary
- Adds `objectConditionClassification` to the `NormalizedKey` type and `PREFIX_MAP` in `normalizeValueKey`, so JSON fields using this prefix get normalized alongside the other `object*` keys.

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — all 61 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)