### PR TITLE
chore: add UPenn clinvar manuscript export scripts

### DIFF
--- a/scripts/miscellaneous/compose-gcs-shards.sh
+++ b/scripts/miscellaneous/compose-gcs-shards.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+BUCKET="gs://clingen-public/upenn/clinvar_scvs_pre_2019_07_01"
+SHARDS_DIR="${BUCKET}/temp_shards"
+FINAL="${BUCKET}/clinvar_scvs_pre_2019_07_01.json.gz"
+
+# Get all shard files sorted
+shards=($(gsutil ls "${SHARDS_DIR}/part_*.json.gz" | sort))
+total=${#shards[@]}
+echo "Total shards: $total"
+
+if [ "$total" -le 32 ]; then
+  gsutil compose "${shards[@]}" "$FINAL"
+else
+  # Compose in batches of 32, then compose the intermediates
+  batch_size=32
+  intermediates=()
+  batch_num=0
+
+  for ((i=0; i<total; i+=batch_size)); do
+    batch=("${shards[@]:i:batch_size}")
+    intermediate="${SHARDS_DIR}/_intermediate_${batch_num}.json.gz"
+    echo "Composing batch $batch_num (${#batch[@]} files)..."
+    gsutil compose "${batch[@]}" "$intermediate"
+    intermediates+=("$intermediate")
+    ((batch_num++))
+  done
+
+  # Final compose of intermediates
+  echo "Composing ${#intermediates[@]} intermediates into final file..."
+  gsutil compose "${intermediates[@]}" "$FINAL"
+
+  # Clean up intermediates
+  echo "Cleaning up intermediates..."
+  gsutil rm "${intermediates[@]}"
+fi
+
+echo "Done: $FINAL"

--- a/scripts/miscellaneous/export-data.sql
+++ b/scripts/miscellaneous/export-data.sql
@@ -1,0 +1,72 @@
+// one off for UPENN clinvar manuscript
+
+EXPORT DATA OPTIONS(
+  uri='gs://clingen-public/upenn/clinvar_scvs_pre_2019_07_01/temp_shards/part_*.json.gz',
+  format='JSON',
+  compression='GZIP',
+  overwrite=true
+) AS
+SELECT
+  s.variation_id,
+  s.id,
+  s.version,
+  CONCAT(s.id, '.', CAST(s.version AS STRING)) AS full_scv_id,
+  s.cvc_stmt_type AS rpt_stmt_type,
+  s.rank,
+  s.last_evaluated,
+  s.classif_type,
+  s.submitted_classification,
+  s.significance AS clinsig_type,
+  CAST(NULL AS STRING) AS classification_label,
+  CAST(NULL AS STRING) AS classification_abbrev,
+  s.submitter_id,
+  sub.current_name AS submitter_name,
+  sub.current_abbrev AS submitter_abbrev,
+  s.submission_date,
+  s.origin,
+  s.affected_status,
+  s.method_type,
+  s.release_date,
+  CAST(NULL AS DATE) AS start_release_date,
+  CAST(NULL AS DATE) AS end_release_date,
+  CAST(NULL AS DATE) AS deleted_release_date,
+  CAST(NULL AS INTEGER) AS deleted_count
+FROM `clingen-stage.clinvar_2019_06_01_v0.scv_summary` s
+LEFT JOIN `clingen-stage.clinvar_2019_06_01_v0.submitter` sub
+  ON s.submitter_id = sub.id
+  AND s.release_date = sub.release_date
+order by variation_id, id, release_date;
+
+
+
+EXPORT DATA OPTIONS(
+  uri='gs://clingen-public/upenn/clinvar_scvs_2019_07_01/temp_shards/part_*.json.gz',
+  format='JSON',
+  compression='GZIP',
+  overwrite=true
+) AS
+SELECT
+  variation_id,
+  id,
+  version,
+  full_scv_id,
+  rpt_stmt_type,
+  rank,
+  last_evaluated,
+  classif_type,
+  submitted_classification,
+  clinsig_type,
+  classification_label,
+  classification_abbrev,
+  submitter_id,
+  submitter_name,
+  submitter_abbrev,
+  submission_date,
+  origin,
+  affected_status,
+  method_type,
+  start_release_date,
+  end_release_date,
+  deleted_release_date,
+  deleted_count
+FROM `clingen-dev.clingen_stage.historic_voi_scv_copy` ;

--- a/scripts/miscellaneous/export-schema-differences.md
+++ b/scripts/miscellaneous/export-schema-differences.md
@@ -1,0 +1,40 @@
+# Schema Differences: Pre-2019-07-01 vs 2019-07-01+ Exports
+
+## Overview
+
+Both exports produce GZIP-compressed JSON shards to GCS under `gs://clingen-public/upenn/`. They share the same set of output columns but differ in their source tables and how certain fields are derived.
+
+## Source Tables
+
+| Export | Source |
+|---|---|
+| **pre_2019_07_01** | `clingen-stage.clinvar_2019_06_01_v0.scv_summary` joined with `.submitter` |
+| **2019_07_01** | `clingen-dev.clingen_stage.historic_voi_scv_copy` (single pre-joined table) |
+
+## Key Differences
+
+### Columns present only in the pre-2019 export
+- **`release_date`** — the per-record release date from the source snapshot. Not included in the post-2019 export.
+
+### Columns present only in the post-2019 export
+- **`start_release_date`** — first release date the SCV appeared.
+- **`end_release_date`** — last release date the SCV was present.
+- **`deleted_release_date`** — release date the SCV was removed.
+- **`deleted_count`** — number of times the SCV was deleted.
+
+In the pre-2019 export these four fields (`start_release_date`, `end_release_date`, `deleted_release_date`, `deleted_count`) are projected as `NULL` placeholders to keep the schema compatible.
+
+### Column aliasing
+The pre-2019 export renames several source columns to match the post-2019 schema:
+- `s.cvc_stmt_type` → `rpt_stmt_type`
+- `s.significance` → `clinsig_type`
+- `sub.current_name` → `submitter_name`
+- `sub.current_abbrev` → `submitter_abbrev`
+- `CONCAT(s.id, '.', CAST(s.version AS STRING))` → `full_scv_id` (computed)
+- `classification_label` and `classification_abbrev` are cast as `NULL` (not available in the older dataset)
+
+The post-2019 export selects these columns directly by their final names, indicating the `historic_voi_scv_copy` table already has the normalized schema.
+
+### Ordering
+- **pre_2019_07_01** — explicitly ordered by `variation_id, id, release_date`.
+- **2019_07_01** — no ordering specified.

--- a/scripts/projects/significance-change-analysis/compose-gcs-shards.sh
+++ b/scripts/projects/significance-change-analysis/compose-gcs-shards.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+BUCKET="gs://clingen-public/upenn/clinvar_scvs_pre_2019_07_01"
+SHARDS_DIR="${BUCKET}/temp_shards"
+FINAL="${BUCKET}/clinvar_scvs_pre_2019_07_01.json.gz"
+
+# Get all shard files sorted
+shards=($(gsutil ls "${SHARDS_DIR}/part_*.json.gz" | sort))
+total=${#shards[@]}
+echo "Total shards: $total"
+
+if [ "$total" -le 32 ]; then
+  gsutil compose "${shards[@]}" "$FINAL"
+else
+  # Compose in batches of 32, then compose the intermediates
+  batch_size=32
+  intermediates=()
+  batch_num=0
+
+  for ((i=0; i<total; i+=batch_size)); do
+    batch=("${shards[@]:i:batch_size}")
+    intermediate="${SHARDS_DIR}/_intermediate_${batch_num}.json.gz"
+    echo "Composing batch $batch_num (${#batch[@]} files)..."
+    gsutil compose "${batch[@]}" "$intermediate"
+    intermediates+=("$intermediate")
+    ((batch_num++))
+  done
+
+  # Final compose of intermediates
+  echo "Composing ${#intermediates[@]} intermediates into final file..."
+  gsutil compose "${intermediates[@]}" "$FINAL"
+
+  # Clean up intermediates
+  echo "Cleaning up intermediates..."
+  gsutil rm "${intermediates[@]}"
+fi
+
+echo "Done: $FINAL"


### PR DESCRIPTION
## Summary

- Adds one-off scripts for exporting pre/post-2019 SCV data to GCS for the UPenn ClinVar manuscript collaboration
- `scripts/miscellaneous/export-data.sql` — BigQuery export queries for pre-2019 and post-2019 SCV data
- `scripts/miscellaneous/compose-gcs-shards.sh` — Composes GCS JSON shards into single files (handles >32 shard limit)
- `scripts/miscellaneous/export-schema-differences.md` — Documents schema differences between the two exports
- `scripts/projects/significance-change-analysis/compose-gcs-shards.sh` — GCS shard composition for significance change analysis

## Test plan

- [ ] Verify export queries reference valid source tables
- [ ] Verify compose script handles shard batching correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)